### PR TITLE
Fixes #27 (MessagesNotificationViewService crash in extensions)

### DIFF
--- a/src/Headers.h
+++ b/src/Headers.h
@@ -270,6 +270,7 @@ extern NSBundle *CKFrameworkBundle(void);
 
 @interface CKChatItem : NSObject
 @property (retain, nonatomic) IMTranscriptChatItem *IMChatItem;
+@property(copy, nonatomic) NSAttributedString *transcriptDrawerText;
 @end
 
 @interface CKMediaObject : NSObject

--- a/src/ThirdPartyApp.m
+++ b/src/ThirdPartyApp.m
@@ -40,7 +40,9 @@ CHOptimizedMethod(0, super, void, CouriaInlineReplyViewController_ThirdPartyApp,
                 }];
             }
             messageItem.context = [IMMessage messageFromIMMessageItem:messageItem sender:nil subject:nil];
-            [chatItems addObject:[self.conversationViewController chatItemWithIMChatItem:messageItem._newChatItems]];
+            CKChatItem *chatItem = [self.conversationViewController chatItemWithIMChatItem:messageItem._newChatItems];
+            chatItem.transcriptDrawerText = [[NSAttributedString alloc] initWithString:messageItem.plainBody];
+            [chatItems addObject:chatItem];
         }];
         self.conversationViewController.chatItems = chatItems;
     } else {


### PR DESCRIPTION
Fix for issue #27 where MessagesNotificationViewService will crash when
loading messages in third party extensions.  Set’s the CKChatItem’s
transcriptDrawerText to an attributed string using the IMMessageItem’s
plainBody.